### PR TITLE
changed node_block_name and int selector names

### DIFF
--- a/modules/leaf_interface_selectors_block/variables.tf
+++ b/modules/leaf_interface_selectors_block/variables.tf
@@ -22,7 +22,7 @@ variable "port_block" {
       interface_selector = ""
       module_from        = 1
       module_to          = 1 # The default value is the same as module_from.
-      name               = "Eth1-1"
+      name               = "block2"
       name_alias         = ""
       port_from          = 1
       port_to            = 1 # The default value is the same as port_from.
@@ -38,7 +38,7 @@ locals {
       interface_selector = (v.interface_selector != null ? v.interface_selector : "")
       module_from        = coalesce(v.module_from, 1)
       module_to          = coalesce(v.module_to, v.module_from, 1)
-      name               = coalesce(v.name, "Eth1-1")
+      name               = coalesce(v.name, "block2")
       name_alias         = (v.name_alias != null ? v.name_alias : "")
       port_from          = coalesce(v.port_from, 1)
       port_to            = coalesce(v.port_to, v.port_from, 1)

--- a/modules/leaf_profile_single/variables.tf
+++ b/modules/leaf_profile_single/variables.tf
@@ -41,7 +41,7 @@ locals {
       name                    = coalesce(v.name, "leaf101")
       name_alias              = (v.name_alias != null ? v.name_alias : "")
       node_block_from         = coalesce(v.node_block_from, 201)
-      node_block_name         = coalesce(v.node_block_name, "blk1")
+      node_block_name         = coalesce(v.node_block_name, "bl${coalesce(v.node_block_from, 201)}${coalesce(v.node_block_to, 201)}")
       node_block_to           = coalesce(v.node_block_to, 201)
       leaf_selector_name      = coalesce(v.leaf_selector_name, "leaf101")
       leaf_interface_profile  = (v.leaf_interface_profile != null ? v.leaf_interface_profile : "")


### PR DESCRIPTION
currently node_block_name and interface selector port block names are configurable by end user. When we configure these policies via APIC gui we can see that these names are automatically generated.
For node_block_name the pattern is "bl<leaf_id_from><leaf_id_to>".
interface selector port block name is the same for all block "block2"